### PR TITLE
Update `row.name` to `row.title`

### DIFF
--- a/alfred/src/add_task.py
+++ b/alfred/src/add_task.py
@@ -21,7 +21,7 @@ try:
     status = ' '.join(args.status)
 
     row = collection.add_row()
-    row.name = query
+    row.title = query
     row.status = status
 
     if args.tags:


### PR DESCRIPTION
It seems that `row.name` is no longer a valid property.
Listing `row` properties, I saw `title` available.
Worked like a charm as soon as made this change!