### PR TITLE
Feat allow set custom week start day

### DIFF
--- a/alfred/README.md
+++ b/alfred/README.md
@@ -62,7 +62,9 @@ Given the information we've taken note of in the last 2 sections, we can now con
     "TAGS_DATABASE_URL": "your-notion-tags-database-url",
     "TASKS_DATABASE_URL": "your-notion-tasks-database-url",
     "WINS_DATABASE_URL": "your-notion-wins-database-url",
-    "YEAR_PAGE_URL": "your-notion-year-page-url"
+    "YEAR_PAGE_URL": "your-notion-year-page-url",
+    "WEEK_STARTS_ON_SUNDAY": true,
+    "CUSTOM_DAY_FORMAT": "strftime-day-format-inside-days-column"
   }
 ```
 

--- a/alfred/README.md
+++ b/alfred/README.md
@@ -62,10 +62,15 @@ Given the information we've taken note of in the last 2 sections, we can now con
     "TAGS_DATABASE_URL": "your-notion-tags-database-url",
     "TASKS_DATABASE_URL": "your-notion-tasks-database-url",
     "WINS_DATABASE_URL": "your-notion-wins-database-url",
-    "YEAR_PAGE_URL": "your-notion-year-page-url",
+    "YEAR_PAGE_URL": "your-notion-year-page-url"
+  }
+```
+
+_Note:_ these are optional configs for additional customization:
+
+```
     "WEEK_STARTS_ON_SUNDAY": true,
     "CUSTOM_DAY_FORMAT": "strftime-day-format-inside-days-column"
-  }
 ```
 
 _Note:_ I know that this is a rather unconventional approach for configurations with an Alfred workflow, but it is what worked best for me. Later on, I might switch it up to something more conventional.

--- a/alfred/data/config.sample.json
+++ b/alfred/data/config.sample.json
@@ -5,5 +5,6 @@
   "WINS_DATABASE_URL": "your-notion-wins-database-url",
   "YEAR_PAGE_URL": "your-notion-year-page-url",
   "IFTTT_TIMEBLOCKING_APPLET_URL": "https://maker.ifttt.com/trigger/your-event/with/key/your-key",
-  "WEEK_START_ON_SUNDAY": true
+  "WEEK_STARTS_ON_SUNDAY": true,
+  "CUSTOM_DAY_FORMAT": null
 }

--- a/alfred/data/config.sample.json
+++ b/alfred/data/config.sample.json
@@ -4,7 +4,5 @@
   "TASKS_DATABASE_URL": "your-notion-tasks-database-url",
   "WINS_DATABASE_URL": "your-notion-wins-database-url",
   "YEAR_PAGE_URL": "your-notion-year-page-url",
-  "IFTTT_TIMEBLOCKING_APPLET_URL": "https://maker.ifttt.com/trigger/your-event/with/key/your-key",
-  "WEEK_STARTS_ON_SUNDAY": true,
-  "CUSTOM_DAY_FORMAT": null
+  "IFTTT_TIMEBLOCKING_APPLET_URL": "https://maker.ifttt.com/trigger/your-event/with/key/your-key"
 }

--- a/alfred/data/config.sample.json
+++ b/alfred/data/config.sample.json
@@ -4,5 +4,6 @@
   "TASKS_DATABASE_URL": "your-notion-tasks-database-url",
   "WINS_DATABASE_URL": "your-notion-wins-database-url",
   "YEAR_PAGE_URL": "your-notion-year-page-url",
-  "IFTTT_TIMEBLOCKING_APPLET_URL": "https://maker.ifttt.com/trigger/your-event/with/key/your-key"
+  "IFTTT_TIMEBLOCKING_APPLET_URL": "https://maker.ifttt.com/trigger/your-event/with/key/your-key",
+  "WEEK_START_ON_SUNDAY": true
 }

--- a/alfred/src/config.py
+++ b/alfred/src/config.py
@@ -43,3 +43,7 @@ class Config():
     @cached(cache={})
     def year_page_url(self):
         return self.config_json()['YEAR_PAGE_URL']
+
+    @cached(cache={})
+    def week_starts_on_sunday(self):
+        return self.config_json()['WEEK_STARTS_ON_SUNDAY']

--- a/alfred/src/config.py
+++ b/alfred/src/config.py
@@ -46,8 +46,8 @@ class Config():
 
     @cached(cache={})
     def week_starts_on_sunday(self):
-        return self.config_json()['WEEK_STARTS_ON_SUNDAY']
+        return self.config_json().get('WEEK_STARTS_ON_SUNDAY', True)
 
     @cached(cache={})
     def custom_day_format(self):
-        return self.config_json()['CUSTOM_DAY_FORMAT']
+        return self.config_json().get('CUSTOM_DAY_FORMAT', "%B %-d")

--- a/alfred/src/config.py
+++ b/alfred/src/config.py
@@ -47,3 +47,7 @@ class Config():
     @cached(cache={})
     def week_starts_on_sunday(self):
         return self.config_json()['WEEK_STARTS_ON_SUNDAY']
+
+    @cached(cache={})
+    def custom_day_format(self):
+        return self.config_json()['CUSTOM_DAY_FORMAT']

--- a/shared/notionscripts/config.py
+++ b/shared/notionscripts/config.py
@@ -28,3 +28,7 @@ class Config():
     @cached(cache={})
     def imported_tag_url(self):
         return os.environ.get('IMPORTED_TAG_URL')
+
+    @cached(cache={})
+    def week_starts_on_sunday(self):
+        return os.environ.get('WEEK_STARTS_ON_SUNDAY')

--- a/shared/notionscripts/config.py
+++ b/shared/notionscripts/config.py
@@ -32,3 +32,7 @@ class Config():
     @cached(cache={})
     def week_starts_on_sunday(self):
         return os.environ.get('WEEK_STARTS_ON_SUNDAY')
+
+    @cached(cache={})
+    def custom_day_format(self):
+        return os.environ.get('CUSTOM_DAY_FORMAT')

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -45,7 +45,7 @@ class NotionApi():
         current_date = datetime.now()
 
         week_number = current_date.isocalendar()[1]
-        if self.config.week_starts_on_sunday:
+        if self.config.week_starts_on_sunday():
             week_number = str(week_number + (current_date.isoweekday() == 7))
 
         for week_page in self.current_year().children:
@@ -64,7 +64,7 @@ class NotionApi():
 
         # example: Sunday 6
         day_name = current_date.strftime("%B %-d")
-        if self.config.custom_day_format:
+        if self.config.custom_day_format():
             day_name = current_date.strftime(self.config.custom_day_format())
 
         days_page = self.current_week().children[1].children[1]

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -62,11 +62,7 @@ class NotionApi():
         found_day = None
         current_date = datetime.now()
 
-        # example: Sunday 6
-        day_name = current_date.strftime("%B %-d")
-        if self.config.custom_day_format():
-            day_name = current_date.strftime(self.config.custom_day_format())
-
+        day_name = current_date.strftime(self.config.custom_day_format())
         days_page = self.current_week().children[1].children[1]
 
         for day_page in days_page.children:

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -62,12 +62,15 @@ class NotionApi():
         found_day = None
         current_date = datetime.now()
 
-        day_number = str(current_date.day)
-        month_name = current_date.strftime("%B")
+        # example: Sunday 6
+        day_name = current_date.strftime("%B %-d")
+        if self.config.custom_day_format:
+            day_name = current_date.strftime(self.config.custom_day_format())
+
         days_page = self.current_week().children[1].children[1]
 
         for day_page in days_page.children:
-            if day_page.title.startswith(month_name + " " + day_number):
+            if day_page.title.startswith(day_name):
                 found_day = day_page
                 break
             else:

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -44,12 +44,12 @@ class NotionApi():
         found_week = None
         current_date = datetime.now()
 
-        # Sunday Starts the week
-        week_number = str(current_date.isocalendar()[
-                         1] + (current_date.isoweekday() == 7))
+        week_number = current_date.isocalendar()[1]
+        if self.config.week_starts_on_sunday:
+            week_number = str(week_number + (current_date.isoweekday() == 7))
 
         for week_page in self.current_year().children:
-            if week_page.title.startswith("Week " + week_number):
+            if week_page.title.startswith("Week {}".format(week_number)):
                 found_week = week_page
                 break
             else:


### PR DESCRIPTION
This PR add additional options to setup Week starts day and format of Days column.

Few options were added to config:
- `WEEK_STARTS_ON_SUNDAY` -- boolean, allow changing Week stats day between Sunday and Monday
- `CUSTOM_DAY_FORMAT` -- optional string with `strftime` format. Allow to customize naming of Day inside Days column.