### PR TITLE
fix: 'default_query' function is busted in notion-py, use build_query

### DIFF
--- a/alfred/src/get_tags.py
+++ b/alfred/src/get_tags.py
@@ -13,7 +13,7 @@ try:
 
     if output is None:
         database = notion_api.tags_database()
-        results = database.default_query().execute()
+        results = database.build_query().execute()
 
         tags = [{
             "uid": row.id,

--- a/alfred/src/update_tags.py
+++ b/alfred/src/update_tags.py
@@ -9,7 +9,7 @@ from notion_api import config
 
 try:
     database = notion_api.tags_database()
-    results = database.default_query().execute()
+    results = database.build_query().execute()
 
     tags = [{
         "uid": row.id,


### PR DESCRIPTION
fixes: #17

Getting and updating tags should work after this. The `default_query` doesn't work in `notion-py` currently.

Fortunately, we don't use any special query filtering here, so we can
just swap it to use `build_query` and search for all tags.