### PR TITLE
fix: missing default on the shard config class (for day/week options)

### DIFF
--- a/shared/notionscripts/config.py
+++ b/shared/notionscripts/config.py
@@ -31,8 +31,8 @@ class Config():
 
     @cached(cache={})
     def week_starts_on_sunday(self):
-        return os.environ.get('WEEK_STARTS_ON_SUNDAY')
+        return os.environ.get('WEEK_STARTS_ON_SUNDAY', True)
 
     @cached(cache={})
     def custom_day_format(self):
-        return os.environ.get('CUSTOM_DAY_FORMAT')
+        return os.environ.get('CUSTOM_DAY_FORMAT', "%B %-d")


### PR DESCRIPTION
These defaults were applied in the alfred directory but not in the shared directory. This was done in #16.

Ideally, we'd want to have the configs logic to be in a single place. This can be some future work.

fixes: #20

This might also handle #19