### PR TITLE
feat: add more testing and automatic test page setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
         flake8 . --count --exit-zero --statistics
     - name: Test with pytest
       run: |
-        pytest shared/notionscripts/tests/ --notion_token ${{ secrets.NOTION_TOKEN }}
+        pytest shared/notionscripts/tests/ --notion_token ${{ secrets.NOTION_TOKEN }} --notion_test_parent_page_id ${{ secrets.NOTION_TEST_PARENT_PAGE_ID }} --tb=native

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    focus: only these tests are ran (as they are being worked on)

--- a/server/src/api.py
+++ b/server/src/api.py
@@ -52,7 +52,7 @@ def block_view(notion_token, block_id):
     try:
         notion_api = NotionApi(notion_token)
 
-        content = notion_api.get_block_content(block_id)
+        content = notion_api.block_content(block_id)
 
         return jsonify(content=content), 200
     except Exception as error:

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -14,7 +14,10 @@ class NotionApi():
     def client(self):
         return NotionClient(token_v2=self.token, monitor=False)
 
-    def get_block_content(self, block_id):
+    def __collection_view(self, collection_id, view_id):
+        return self.client().get_collection_view(f"https://www.notion.so/{collection_id}?v={view_id}")
+
+    def block_content(self, block_id):
         block = self.client().get_block(block_id)
 
         content = [block.title]
@@ -24,16 +27,13 @@ class NotionApi():
 
         return "\n".join(content)
 
-    def get_collection_view(self, collection_id, view_id):
-        return self.client().get_collection_view(f"https://www.notion.so/{collection_id}?v={view_id}")
-
     def block_append(self, block_id, text):
         block = self.client().get_block(block_id)
 
         return block.children.add_new(TextBlock, title=text)
 
-    def collection_view(self, collection_id, view_id):
-        collection_view = self.get_collection_view(collection_id, view_id)
+    def collection_view_content(self, collection_id, view_id):
+        collection_view = self.__collection_view(collection_id, view_id)
         results = collection_view.default_query().execute()
 
         content = []
@@ -43,7 +43,7 @@ class NotionApi():
         return content
 
     def collection_append(self, collection_id, view_id, data):
-        collection_view = self.get_collection_view(collection_id, view_id)
+        collection_view = self.__collection_view(collection_id, view_id)
 
         row = collection_view.collection.add_row(**data)
 

--- a/shared/notionscripts/tests/conftest.py
+++ b/shared/notionscripts/tests/conftest.py
@@ -1,13 +1,24 @@
 import pytest
 
+from .notion_api_page_helper import *  # noqa, F401
+
 
 def pytest_addoption(parser):
     parser.addoption("--notion_token", action="store")
+    parser.addoption("--notion_test_parent_page_id", action="store")
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def notion_token(request):
     value = request.config.option.notion_token
+    if value is None:
+        pytest.skip()
+    return value
+
+
+@pytest.fixture(scope="session")
+def notion_test_parent_page_id(request):
+    value = request.config.option.notion_test_parent_page_id
     if value is None:
         pytest.skip()
     return value

--- a/shared/notionscripts/tests/notion_api_page_helper.py
+++ b/shared/notionscripts/tests/notion_api_page_helper.py
@@ -1,0 +1,94 @@
+import pytest
+
+from datetime import datetime
+from notion.client import NotionClient
+from notion.block import PageBlock, CollectionViewBlock
+
+# Some parts of this file are inspired/using the code from notion-py
+# https://github.com/jamalex/notion-py/blob/b7041ade477c1f59edab1b6fc025326d406dd92a/notion/smoke_test.py
+
+
+def get_test_page():
+    return test_page
+
+
+@pytest.fixture(scope="session", autouse=True)
+def setup_test_page(request, notion_token, notion_test_parent_page_id):
+    global notion_client, test_page
+
+    notion_client = NotionClient(token_v2=notion_token, monitor=False)
+    test_page = create_test_page(notion_test_parent_page_id)
+
+    yield
+
+    test_page.remove(permanently=True)
+
+
+def create_test_page(notion_test_parent_page_id):
+    test_parent_page = notion_client.get_block(notion_test_parent_page_id)
+
+    test_page = test_parent_page.children.add_new(
+        PageBlock,
+        title="Test page at {}".format(datetime.now().strftime("%Y-%m-%d %H:%M:%S")),
+    )
+
+    return test_page
+
+
+def create_collection_view():
+    schema = {
+        "%9:q": {"name": "Enabled", "type": "checkbox"},
+        "=d{|": {
+            "name": "Tags",
+            "type": "multi_select",
+            "options": [
+                {
+                    "color": "orange",
+                    "id": "79560dab-c776-43d1-9420-27f4011fcaec",
+                    "value": "A",
+                },
+                {
+                    "color": "default",
+                    "id": "002c7016-ac57-413a-90a6-64afadfb0c44",
+                    "value": "B",
+                },
+                {
+                    "color": "blue",
+                    "id": "77f431ab-aeb2-48c2-9e40-3a630fb86a5b",
+                    "value": "C",
+                },
+            ],
+        },
+        "=d{q": {
+            "name": "Category",
+            "type": "select",
+            "options": [
+                {
+                    "color": "orange",
+                    "id": "59560dab-c776-43d1-9420-27f4011fcaec",
+                    "value": "A",
+                },
+                {
+                    "color": "default",
+                    "id": "502c7016-ac57-413a-90a6-64afadfb0c44",
+                    "value": "B",
+                },
+                {
+                    "color": "blue",
+                    "id": "57f431ab-aeb2-48c2-9e40-3a630fb86a5b",
+                    "value": "C",
+                },
+            ],
+        },
+        "4Jv$": {"name": "Value", "type": "number"},
+        "title": {"name": "Name", "type": "title"},
+    }
+
+    cvb = test_page.children.add_new(CollectionViewBlock)
+    cvb.collection = notion_client.get_collection(
+        notion_client.create_record("collection", parent=cvb, schema=schema)
+    )
+    cvb.title = "Test collection"
+    view = cvb.views.add_new(view_type="table")
+
+    return view


### PR DESCRIPTION
I'm borrowing some test code from notion-py for setting up the test
page and a collection within it.

This makes it so that each test run can have its own page. For the time
being I'm making it so that each test is just adding/removing/changing
what it needs. It might make sense to break each test into their own
setups for a perfect clean slate.

Added a new notion_test_parent_page_id option on the pytest to specify
where the new test pages are made.

Finished adding tests for the rest of the NotionApi functions. I've
opt'd to use notion-py directly in these tests for data setup. Then the
NotionApi class is uses.