### PR TITLE
Add ability to update collection blocks

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -13,10 +13,25 @@ If needed, rate limiting will be used as this server will be running on a free [
 As of right now the following endpoints exist:
 
 ```python
+# Allows you to add a piece of text as a child of the specific block (i.e.,
+# nesting under a text block, or inside a page)
 @app.route('/blocks/<block_id>/append', methods=['POST'])
+
+# Allows you to update the specified block with new values from the JSON body. Text blocks
+# use "title", and collection rows (which are technically blocks) can also
+# specify other columns.
 @app.route('/blocks/<block_id>/update', methods=['PUT'])
+
+# Allows you to view the content of the specified block. It will take the block's title and
+# all of its children's titles and join them with newlines.
 @app.route('/blocks/<block_id>/view', methods=['GET'])
+
+# Allows you to append a new row onto the specificed collection view with the
+# values from the JSON body.
 @app.route('/collections/<collection_id>/<view_id>/append', methods=['POST'])
+
+# Allows you to view all the rows of the specified collection view with all the
+# column values present.
 @app.route('/collections/<collection_id>/<view_id>/view', methods=['GET'])
 ```
 

--- a/server/src/api.py
+++ b/server/src/api.py
@@ -39,7 +39,7 @@ def block_append(notion_token, block_id):
     try:
         notion_api = NotionApi(notion_token)
 
-        block = notion_api.block_append(block_id, request.json['text'])
+        block = notion_api.block_append(block_id, request.json)
 
         return jsonify(block_id=block.id), 200
     except Exception as error:
@@ -52,7 +52,7 @@ def block_update(notion_token, block_id):
     try:
         notion_api = NotionApi(notion_token)
 
-        block = notion_api.block_update(block_id, request.json['text'])
+        block = notion_api.block_update(block_id, request.json)
 
         return jsonify(block_id=block.id), 200
     except Exception as error:
@@ -91,7 +91,7 @@ def collection_view(notion_token, collection_id, view_id):
     try:
         notion_api = NotionApi(notion_token)
 
-        content = notion_api.collection_view(collection_id, view_id)
+        content = notion_api.collection_view_content(collection_id, view_id)
 
         return jsonify(rows=content), 200
     except Exception as error:

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -27,15 +27,17 @@ class NotionApi():
 
         return "\n".join(content)
 
-    def block_append(self, block_id, text):
+    def block_append(self, block_id, data):
         block = self.client().get_block(block_id)
 
-        return block.children.add_new(TextBlock, title=text)
+        return block.children.add_new(TextBlock, title=data["title"])
 
-    def block_update(self, block_id, text):
+    def block_update(self, block_id, data):
         block = self.client().get_block(block_id)
 
-        block.title = text
+        with self.client().as_atomic_transaction():
+            for key, val in data.items():
+                setattr(block, key, val)
 
         return block
 

--- a/shared/notionscripts/tests/test_notion_api.py
+++ b/shared/notionscripts/tests/test_notion_api.py
@@ -22,20 +22,33 @@ def test_block_append(notion_token):
     test_page = get_test_page()
 
     block = test_page.children.add_new(TextBlock, title="test block append")
-    new_block = notion_api.block_append(block.id, "appending text")
+    new_block = notion_api.block_append(block.id, {"title": "appending text"})
 
     assert new_block.title == "appending text"
     assert new_block.parent.id == block.id
 
 
-def test_block_update(notion_token):
+def test_block_update_with_text_block(notion_token):
     notion_api = NotionApi(token=notion_token)
     test_page = get_test_page()
 
     block = test_page.children.add_new(TextBlock, title="test block update")
-    updated_block = notion_api.block_update(block.id, "test block has been updated")
+    updated_block = notion_api.block_update(block.id, {"title": "test block has been updated"})
 
     assert updated_block.title == "test block has been updated"
+    assert updated_block.id == block.id
+
+
+def test_block_update_with_collection_block(notion_token):
+    notion_api = NotionApi(token=notion_token)
+
+    collection_view = create_collection_view()
+    block = collection_view.collection.add_row(name="test row", value=10, enabled=True)
+
+    updated_block = notion_api.block_update(block.id, {"title": "test block has been updated", "value": 5})
+
+    assert updated_block.title == "test block has been updated"
+    assert updated_block.value == 5
     assert updated_block.id == block.id
 
 


### PR DESCRIPTION
The block_update function now accommodates multiple properties in the
json body of the request. This makes it work for both normal text blocks
which use the 'title' property as well as collection blocks.

I made the block_update use an atomic_transactions so that everything
updates or nothing does.

I fixed a missing update on the collection_view_content method.

Update server endpoint docs.