### PR TITLE
feat: add a new /blocks/<block_id>/children endpoint

### DIFF
--- a/server/src/api.py
+++ b/server/src/api.py
@@ -41,7 +41,7 @@ def block_append(notion_token, block_id):
 
         block = notion_api.block_append(block_id, request.json)
 
-        return jsonify(block_id=block.id), 200
+        return jsonify(id=block.id), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -54,7 +54,7 @@ def block_update(notion_token, block_id):
 
         block = notion_api.block_update(block_id, request.json)
 
-        return jsonify(block_id=block.id), 200
+        return jsonify(id=block.id), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -67,7 +67,7 @@ def block_delete(notion_token, block_id):
 
         block = notion_api.block_delete(block_id)
 
-        return jsonify(block_id=block.id), 200
+        return jsonify(id=block.id), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -80,7 +80,20 @@ def block_view(notion_token, block_id):
 
         content = notion_api.block_content(block_id)
 
-        return jsonify(content=content), 200
+        return jsonify(content), 200
+    except Exception as error:
+        return jsonify(error=str(error)), 500
+
+
+@app.route('/blocks/<block_id>/children', methods=['GET'])
+@token_required
+def block_children(notion_token, block_id):
+    try:
+        notion_api = NotionApi(notion_token)
+
+        content = notion_api.block_children(block_id)
+
+        return jsonify(content), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -20,17 +20,23 @@ class NotionApi():
     def block_content(self, block_id):
         block = self.client().get_block(block_id)
 
-        content = [block.title]
-        for child in block.children:
-            if hasattr(child, "title"):
-                content.append(child.title)
+        return {"id": block.id, "title": block.title}
 
-        return "\n".join(content)
+    def block_children(self, block_id):
+        block = self.client().get_block(block_id)
+
+        content = []
+        for child in block.children:
+            content.append({"id": child.id, "title": child.title})
+
+        return content
 
     def block_append(self, block_id, data):
         block = self.client().get_block(block_id)
 
-        return block.children.add_new(TextBlock, title=data["title"])
+        new_block = block.children.add_new(TextBlock, title=data["title"])
+
+        return new_block
 
     def block_update(self, block_id, data):
         block = self.client().get_block(block_id)

--- a/shared/notionscripts/tests/test_notion_api.py
+++ b/shared/notionscripts/tests/test_notion_api.py
@@ -14,7 +14,21 @@ def test_block_content(notion_token):
     block = test_page.children.add_new(TextBlock, title="test get block content")
     content = notion_api.block_content(block.id)
 
-    assert content == "test get block content"
+    assert content == {"id": block.id, "title": "test get block content"}
+
+
+def test_block_children(notion_token):
+    notion_api = NotionApi(token=notion_token)
+    test_page = get_test_page()
+
+    block = test_page.children.add_new(TextBlock, title="a parent block")
+    child_block_1 = block.children.add_new(TextBlock, title="child block 1")
+    child_block_2 = block.children.add_new(TextBlock, title="child block 2")
+
+    content = notion_api.block_children(block.id)
+
+    assert content[0] == {"id": child_block_1.id, "title": "child block 1"}
+    assert content[1] == {"id": child_block_2.id, "title": "child block 2"}
 
 
 def test_block_append(notion_token):


### PR DESCRIPTION
This endpoint lists the children of the block.

A slight revamp of the block_view and block_content functions so that
it only shows the block's single title instead of its children as well.

The api for the block viewing endpoints now returns more json style
response.

fixes: #31 