### PR TITLE
Add and use block presenter

### DIFF
--- a/server/src/api.py
+++ b/server/src/api.py
@@ -41,7 +41,7 @@ def block_append(notion_token, block_id):
 
         block = notion_api.block_append(block_id, request.json)
 
-        return jsonify(id=block.id), 200
+        return jsonify(block), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -54,7 +54,7 @@ def block_update(notion_token, block_id):
 
         block = notion_api.block_update(block_id, request.json)
 
-        return jsonify(id=block.id), 200
+        return jsonify(block), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -67,7 +67,7 @@ def block_delete(notion_token, block_id):
 
         block = notion_api.block_delete(block_id)
 
-        return jsonify(id=block.id), 200
+        return jsonify(block), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -78,9 +78,9 @@ def block_view(notion_token, block_id):
     try:
         notion_api = NotionApi(notion_token)
 
-        content = notion_api.block_content(block_id)
+        block = notion_api.block_content(block_id)
 
-        return jsonify(content), 200
+        return jsonify(block), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -91,9 +91,9 @@ def block_children(notion_token, block_id):
     try:
         notion_api = NotionApi(notion_token)
 
-        content = notion_api.block_children(block_id)
+        children = notion_api.block_children(block_id)
 
-        return jsonify(content), 200
+        return jsonify(children), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 
@@ -106,7 +106,7 @@ def collection_append(notion_token, collection_id, view_id):
 
         row = notion_api.collection_append(collection_id, view_id, request.json)
 
-        return jsonify(row=row), 200
+        return jsonify(row), 200
     except Exception as error:
         return jsonify(error=str(error)), 500
 

--- a/shared/notionscripts/block_presenter.py
+++ b/shared/notionscripts/block_presenter.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env -S PATH="${PATH}:/usr/local/bin" python3
+
+from notion.collection import CollectionRowBlock
+
+
+class BlockPresenter(dict):
+
+    def __init__(self, block):
+        self.block = block
+        if isinstance(block, CollectionRowBlock):
+            dict.__init__(self, **{"id": block.id, **block.get_all_properties()})
+        else:
+            dict.__init__(self, **{"id": block.id, "title": block.title})

--- a/shared/notionscripts/notion_api.py
+++ b/shared/notionscripts/notion_api.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env -S PATH="${PATH}:/usr/local/bin" python3
+from notionscripts.block_presenter import BlockPresenter
 
 from cachetools import cached
 
@@ -20,23 +21,19 @@ class NotionApi():
     def block_content(self, block_id):
         block = self.client().get_block(block_id)
 
-        return {"id": block.id, "title": block.title}
+        return BlockPresenter(block)
 
     def block_children(self, block_id):
         block = self.client().get_block(block_id)
 
-        content = []
-        for child in block.children:
-            content.append({"id": child.id, "title": child.title})
-
-        return content
+        return [BlockPresenter(child) for child in block.children]
 
     def block_append(self, block_id, data):
         block = self.client().get_block(block_id)
 
         new_block = block.children.add_new(TextBlock, title=data["title"])
 
-        return new_block
+        return BlockPresenter(new_block)
 
     def block_update(self, block_id, data):
         block = self.client().get_block(block_id)
@@ -45,28 +42,24 @@ class NotionApi():
             for key, val in data.items():
                 setattr(block, key, val)
 
-        return block
+        return BlockPresenter(block)
 
     def block_delete(self, block_id):
         block = self.client().get_block(block_id)
 
         block.remove()
 
-        return block
+        return BlockPresenter(block)
 
     def collection_view_content(self, collection_id, view_id):
         collection_view = self.__collection_view(collection_id, view_id)
         results = collection_view.default_query().execute()
 
-        content = []
-        for row in results:
-            content.append(row.get_all_properties())
-
-        return content
+        return [BlockPresenter(row) for row in results]
 
     def collection_append(self, collection_id, view_id, data):
         collection_view = self.__collection_view(collection_id, view_id)
 
         row = collection_view.collection.add_row(**data)
 
-        return row.get_all_properties()
+        return BlockPresenter(row)

--- a/shared/notionscripts/tests/test_block_presenter.py
+++ b/shared/notionscripts/tests/test_block_presenter.py
@@ -1,0 +1,28 @@
+from notionscripts.block_presenter import BlockPresenter
+
+from .notion_api_page_helper import get_test_page, create_collection_view
+
+from notion.block import TextBlock
+
+import json
+
+import pytest  # noqa, F401
+
+
+def test_block_presentation(notion_token):
+    test_page = get_test_page()
+
+    block = test_page.children.add_new(TextBlock, title="textblock")
+
+    assert BlockPresenter(block).block == block
+    assert BlockPresenter(block) == {"id": block.id, "title": "textblock"}
+    assert json.dumps(BlockPresenter(block)) == '{"id": "%s", "title": "textblock"}' % block.id
+
+
+def test_collection_row_block_presentation(notion_token):
+    collection_view = create_collection_view()
+    block = collection_view.collection.add_row(name="test row", value=10, enabled=True)
+
+    assert BlockPresenter(block).block == block
+    assert BlockPresenter(block) == {"id": block.id, "enabled": True, "tags": [], "category": None, "value": 10, "name": "test row"}
+    assert json.dumps(BlockPresenter(block)) == '{"id": "%s", "enabled": true, "tags": [], "category": null, "value": 10, "name": "test row"}' % block.id

--- a/shared/notionscripts/tests/test_notion_api.py
+++ b/shared/notionscripts/tests/test_notion_api.py
@@ -38,8 +38,8 @@ def test_block_append(notion_token):
     block = test_page.children.add_new(TextBlock, title="test block append")
     new_block = notion_api.block_append(block.id, {"title": "appending text"})
 
-    assert new_block.title == "appending text"
-    assert new_block.parent.id == block.id
+    assert new_block == {"id": new_block.block.id, "title": "appending text"}
+    assert new_block.block.parent.id == block.id
 
 
 def test_block_update_with_text_block(notion_token):
@@ -49,8 +49,7 @@ def test_block_update_with_text_block(notion_token):
     block = test_page.children.add_new(TextBlock, title="test block update")
     updated_block = notion_api.block_update(block.id, {"title": "test block has been updated"})
 
-    assert updated_block.title == "test block has been updated"
-    assert updated_block.id == block.id
+    assert updated_block == {"id": block.id, "title": "test block has been updated"}
 
 
 def test_block_update_with_collection_block(notion_token):
@@ -59,11 +58,9 @@ def test_block_update_with_collection_block(notion_token):
     collection_view = create_collection_view()
     block = collection_view.collection.add_row(name="test row", value=10, enabled=True)
 
-    updated_block = notion_api.block_update(block.id, {"title": "test block has been updated", "value": 5})
+    updated_block = notion_api.block_update(block.id, {"name": "test block has been updated", "value": 5})
 
-    assert updated_block.title == "test block has been updated"
-    assert updated_block.value == 5
-    assert updated_block.id == block.id
+    assert updated_block == {"id": block.id, "name": "test block has been updated", "value": 5, "category": None, "enabled": True, "tags": []}
 
 
 def test_block_delete_with_text_block(notion_token):


### PR DESCRIPTION
The idea here is that the block presenter wraps the block result from
notion-py to be used in the API. It inherits from 'dict' so that jsonify
will auto convert it to the raw values that the block presenter has.

As BlockPresenter auto distinguishes between CollectionRowBlocks and
TextBlocks. This makes the API results richer in information.